### PR TITLE
Remove GCC test due to not support with all instructions now

### DIFF
--- a/plct-gnu-b-extension-1804.sh
+++ b/plct-gnu-b-extension-1804.sh
@@ -15,5 +15,6 @@ cd ..
 ./configure --prefix="$PWD/opt-riscv/" --enable-multilib=true
 
 # you can use make -j* to make speed up
-make report-gcc-newlib -j $(nproc)
+# Remove GCC test due to b-ext is not support completely, we will restart it after B-ext GCC part finish by Sifive
+# make report-gcc-newlib -j $(nproc)
 make report-binutils-newlib -j $(nproc)

--- a/plct-gnu-b-extension-2004.sh
+++ b/plct-gnu-b-extension-2004.sh
@@ -15,5 +15,6 @@ cd ..
 ./configure --prefix="$PWD/opt-riscv/" --enable-multilib=true
 
 # you can use make -j* to make speed up
-make report-gcc-newlib -j $(nproc)
+# Remove GCC test due to b-ext is not support completely, we will restart it after B-ext GCC part finish by Sifive
+# make report-gcc-newlib -j $(nproc)
 make report-binutils-newlib -j $(nproc)

--- a/plct-gnu-b-extension-OS.sh
+++ b/plct-gnu-b-extension-OS.sh
@@ -19,5 +19,6 @@ cd ..
 ./configure --prefix="$PWD/opt-riscv/" --enable-multilib=true
 
 # you can use make -j* to make speed up
-make report-gcc-newlib -j $(nproc)
+# Remove GCC test due to b-ext is not support completely, we will restart it after B-ext GCC part finish by Sifive
+# make report-gcc-newlib -j $(nproc)
 make report-binutils-newlib -j $(nproc)


### PR DESCRIPTION
Remove GCC test due to not support with all instructions now, we will check out it after the b-ext GCC part finished.