### PR TITLE
Update the ci test script for b spec v 1.0

### DIFF
--- a/plct-gnu-b-extension-1804.sh
+++ b/plct-gnu-b-extension-1804.sh
@@ -12,7 +12,7 @@ git checkout jw/riscv-binutils-experiment
 
 # test rv64:
 cd ..
-./configure --prefix="$PWD/opt-riscv/" --with-arch=rv64gcb --with-abi=lp64d --with-mulitilib-generator="rv64gcb-lp64d--"
+./configure --prefix="$PWD/opt-riscv/" --with-arch=rv64gczbazbbzbczbezbfzbpzbrzbszbt --with-abi=lp64d --with-mulitilib-generator="rv64gczbazbbzbczbezbfzbpzbrzbszbt-lp64d--"
 
 # you can use make -j* to make speed up
 # Remove GCC test due to b-ext is not support completely, we will restart it after B-ext GCC part finish by Sifive
@@ -20,6 +20,6 @@ cd ..
 make report-binutils-newlib -j $(nproc)
 
 # test rv32:
-./configure --prefix="$PWD/opt-riscv/" --with-arch=rv32gcb --with-abi=ilp32d --with-mulitilib-generator="rv32gcb-ilp32d--"
+./configure --prefix="$PWD/opt-riscv/" --with-arch=rv32gczbazbbzbczbezbfzbpzbrzbszbt --with-abi=ilp32d --with-mulitilib-generator="rv32gczbazbbzbczbezbfzbpzbrzbszbt-ilp32d--"
 make clean 
 make report-binutils-newlib -j $(nproc)

--- a/plct-gnu-b-extension-2004.sh
+++ b/plct-gnu-b-extension-2004.sh
@@ -12,7 +12,7 @@ git checkout jw/riscv-binutils-experiment
 
 # test:
 cd ..
-./configure --prefix="$PWD/opt-riscv/" --with-arch=rv64gcb --with-abi=lp64d --with-mulitilib-generator="rv64gcb-lp64d--"
+./configure --prefix="$PWD/opt-riscv/" --with-arch=rv64gczbazbbzbczbezbfzbpzbrzbszbt --with-abi=lp64d --with-mulitilib-generator="rv64gczbazbbzbczbezbfzbpzbrzbszbt-lp64d--"
 
 # you can use make -j* to make speed up
 # Remove GCC test due to b-ext is not support completely, we will restart it after B-ext GCC part finish by Sifive
@@ -20,6 +20,6 @@ cd ..
 make report-binutils-newlib -j $(nproc)
 
 # test rv32:
-./configure --prefix="$PWD/opt-riscv/" --with-arch=rv32gcb --with-abi=ilp32d --with-mulitilib-generator="rv32gcb-ilp32d--"
+./configure --prefix="$PWD/opt-riscv/" --with-arch=rv32gczbazbbzbczbezbfzbpzbrzbszbt --with-abi=ilp32d --with-mulitilib-generator="rv32gczbazbbzbczbezbfzbpzbrzbszbt-ilp32d--"
 make clean 
 make report-binutils-newlib -j $(nproc)


### PR DESCRIPTION
Update the ci test script for b spec v 1.0, remove the expand of 'b' in test.