### PR TITLE
Follow redirections when downloading SM bootstrap.py

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -41,7 +41,7 @@ if [ -d "mozilla-unified" ];then
    cd mozilla-unified
    hg pull
 else
-   curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O 
+   curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -L -O 
    python3 bootstrap.py  --application-choice=js --no-interactive --no-system-changes
    cd mozilla-unified
 fi

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -37,7 +37,7 @@ hg version
 
 rm -rf ./mozilla-unified
 
-curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O 
+curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -L -O 
 python3 bootstrap.py  --application-choice=js --no-interactive --no-system-changes
 cd mozilla-unified
 


### PR DESCRIPTION
This PR adds the `-L` option to `curl` when downloading SpiderMonkey bootstrap.py.

Resolves #82.