### PR TITLE
Remove `--disable-bootstrap` to use bundled toolchain binary

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -25,7 +25,6 @@ ac_add_options --enable-debug
 # switching between optimized and debug builds while developing.
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
-ac_add_options --disable-bootstrap
 ac_add_options --disable-rust-simd
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit" > mozconfig

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -24,7 +24,6 @@ ac_add_options  --disable-debug
 # switching between optimized and debug builds while developing.
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
-ac_add_options --disable-bootstrap
 ac_add_options --disable-rust-simd
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit" > mozconfig


### PR DESCRIPTION
The most recent build fails due to missing `llvm-objdump`[^1]:

```plain-text
 0:02.60 checking for llvm-objdump... not found
 0:02.60 DEBUG: llvm_objdump: Looking for llvm-objdump
 0:02.60 ERROR: Cannot find llvm-objdump
```

A similar issue is documented in Bug 1526249[^2]. We may either need to install related LLVM tools on the runner or re-enable bootstrapped toolchains to complete building.

This PR implements the latter approach, but feel free to close this and decide on the most suitable solution in the runner environment.

[^1]: https://ci.rvperf.org/job/Spidermonkey-upstream-check/lastBuild/console
[^2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1526249