### PR TITLE
Adapt test command to current `jit-test` version

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -50,8 +50,8 @@ rm -rf ./obj-opt-x86_64-pc-linux-gnu
 
 ./mach build
 
-./mach jstests  --format automation
+./mach jstests --format automation
 
-./mach jittest -t 400 --format automation
-./mach jittest --ion -t 800 --format automation
+./mach jit-test -- -t 400 --format automation
+./mach jit-test -- --ion -t 800 --format automation --no-progress
 ./mach jsapi-tests

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -44,5 +44,4 @@ git log HEAD~1..HEAD
 
 ./mach jsapi-tests
 ./mach jstests -t 400 --format automation
-./mach jittest -ion -t 400 --format automation
-
+./mach jit-test -- --ion -t 400 --format automation --no-progress


### PR DESCRIPTION
This PR adapts outdated test commands to match the latest `jit-test` interface.