### PR TITLE
Sync jstests timeout config between two SM tests

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -49,7 +49,7 @@ rm -rf ./obj-opt-x86_64-pc-linux-gnu
 
 ./mach build
 
-./mach jstests --format automation
+./mach jstests -t 400 --format automation
 
 ./mach jit-test -- -t 400 --format automation
 ./mach jit-test -- --ion -t 800 --format automation --no-progress


### PR DESCRIPTION
This PR syncs jstests timeout config from [Spidermonkey-upstream-fast-check.sh](https://github.com/plctlab/riscv-ci/blob/e46f4dcf4f9b81339e161a2b1faef00725f863d2/Spidermonkey-upstream-fast-check.sh#L45) (now failing due to timeout) to Spidermonkey-upstream-check.sh (now passing).

See also <https://ci.rvperf.org/job/Spidermonkey-upstream-check/761/consoleText#:~:text=TEST-UNEXPECTED-FAIL>.