### PR TITLE
Clean the v8 checkout that may have been from a previous run

### DIFF
--- a/v8-upstream-master-riscv64.py
+++ b/v8-upstream-master-riscv64.py
@@ -104,7 +104,7 @@ def run_tests_all(root, variant):
 
 if __name__ == "__main__":
     fetch_depot_tools()
-    fetch_v8(V8_ROOT_DIR)
+    fetch_v8(V8_ROOT_DIR, clean=True)
 
     build_v8(V8_ROOT_DIR, "riscv64.optdebug.sim", RISCV64_OPTDEBUG_SIM_CONFIG)
     build_v8(V8_ROOT_DIR, "riscv64.release.sim", RISCV64_RELEASE_SIM_CONFIG)


### PR DESCRIPTION
Would fail like this:

```
Traceback (most recent call last):
  File "/home/jenkins_node/workspace/v8-upstream-master-riscv64/riscv-ci/v8-upstream-master-riscv64.py", line 107, in <module>
    fetch_v8(V8_ROOT_DIR)
  File "/home/jenkins_node/workspace/v8-upstream-master-riscv64/riscv-ci/v8-upstream-master-riscv64.py", line 73, in fetch_v8
    exec(["git", "pull"], cwd=v8)
  File "/home/jenkins_node/workspace/v8-upstream-master-riscv64/riscv-ci/v8-upstream-master-riscv64.py", line 59, in exec
    subprocess.run(arguments, cwd=cwd, check=check, env=env)
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'pull']' returned non-zero exit status 1.
Build step 'Execute shell' marked build as failure
```