### PR TITLE
Overhaul SpiderMonkey build options

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -12,11 +12,12 @@ rustc --version
 
 rm -rf $HOME/.mozbuild
 
-echo "# Build only the JS shell
+cat << 'EOF' > mozconfig
+# Build only the JS shell
 ac_add_options --enable-application=js
 
 # Enable optimization for speed
-ac_add_options  --enable-optimize
+ac_add_options --enable-optimize
 
 # Disable debug checks to better match a release build of Firefox.
 ac_add_options --enable-debug
@@ -29,7 +30,8 @@ ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit
-ac_add_options --enable-wasm-jspi" > mozconfig
+ac_add_options --enable-wasm-jspi
+EOF
 
 export MOZCONFIG=$PWD/mozconfig
 

--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -26,7 +26,6 @@ ac_add_options --enable-debug
 # switching between optimized and debug builds while developing.
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
-ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit

--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -26,6 +26,7 @@ ac_add_options --enable-debug
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
 ac_add_options --disable-rust-simd
+ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit" > mozconfig
 

--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -28,7 +28,8 @@ ac_add_options --enable-jitspew
 ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
-ac_add_options --enable-jit" > mozconfig
+ac_add_options --enable-jit
+ac_add_options --enable-wasm-jspi" > mozconfig
 
 export MOZCONFIG=$PWD/mozconfig
 

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -25,6 +25,7 @@ ac_add_options  --disable-debug
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
 ac_add_options --disable-rust-simd
+ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit" > mozconfig
 

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -13,13 +13,14 @@ rustc --version
 
 rm -rf $HOME/.mozbuild
 
-echo "# Build only the JS shell
+cat << 'EOF' > mozconfig
+# Build only the JS shell
 ac_add_options --enable-application=js
 
 # Enable optimization for speed
-ac_add_options  --enable-optimize
+ac_add_options --enable-optimize
 
-ac_add_options  --disable-debug
+ac_add_options --disable-debug
 # Use a separate objdir for optimized builds to allow easy
 # switching between optimized and debug builds while developing.
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
@@ -28,7 +29,8 @@ ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit
-ac_add_options --enable-wasm-jspi" > mozconfig
+ac_add_options --enable-wasm-jspi
+EOF
 
 export MOZCONFIG=$PWD/mozconfig
 

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -25,7 +25,6 @@ ac_add_options --disable-debug
 # switching between optimized and debug builds while developing.
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-opt-@CONFIG_GUESS@
 ac_add_options --enable-jitspew
-ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
 ac_add_options --enable-jit

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -27,7 +27,8 @@ ac_add_options --enable-jitspew
 ac_add_options --disable-rust-simd
 ac_add_options --enable-gczeal
 ac_add_options --enable-simulator=riscv64
-ac_add_options --enable-jit" > mozconfig
+ac_add_options --enable-jit
+ac_add_options --enable-wasm-jspi" > mozconfig
 
 export MOZCONFIG=$PWD/mozconfig
 


### PR DESCRIPTION
This PR tries to rewrite the current SpiderMonkey `mozconfig` to better replicate a real-world build configuration and to improve maintainability.