### PR TITLE
Cover `Zba` and `Zbb` codegen in SpiderMonkey slow test job

### DIFF
--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -52,10 +52,10 @@ rm -rf ./obj-opt-x86_64-pc-linux-gnu
 
 ./mach build
 
-./mach jstests -t 400 --format automation
+./mach jstests -- -t 400 --format automation --no-progress
 
-./mach jit-test -- -t 400 --format automation
+./mach jit-test -- -t 400 --format automation --no-progress
 ./mach jit-test -- --ion -t 400 --format automation --no-progress
-RISCV_EXT_ZBA=1 RISCV_EXT_ZBB=1 ./mach jit-test -- -t 400 --format automation
+RISCV_EXT_ZBA=1 RISCV_EXT_ZBB=1 ./mach jit-test -- -t 400 --format automation --no-progress
 RISCV_EXT_ZBA=1 RISCV_EXT_ZBB=1 ./mach jit-test -- --ion -t 400 --format automation --no-progress
 ./mach jsapi-tests

--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -55,5 +55,5 @@ rm -rf ./obj-opt-x86_64-pc-linux-gnu
 ./mach jstests -t 400 --format automation
 
 ./mach jit-test -- -t 400 --format automation
-./mach jit-test -- --ion -t 800 --format automation --no-progress
+./mach jit-test -- --ion -t 400 --format automation --no-progress
 ./mach jsapi-tests

--- a/Spidermonkey-upstream-check.sh
+++ b/Spidermonkey-upstream-check.sh
@@ -56,4 +56,6 @@ rm -rf ./obj-opt-x86_64-pc-linux-gnu
 
 ./mach jit-test -- -t 400 --format automation
 ./mach jit-test -- --ion -t 400 --format automation --no-progress
+RISCV_EXT_ZBA=1 RISCV_EXT_ZBB=1 ./mach jit-test -- -t 400 --format automation
+RISCV_EXT_ZBA=1 RISCV_EXT_ZBB=1 ./mach jit-test -- --ion -t 400 --format automation --no-progress
 ./mach jsapi-tests

--- a/Spidermonkey-upstream-fast-check.sh
+++ b/Spidermonkey-upstream-fast-check.sh
@@ -45,5 +45,5 @@ git log HEAD~1..HEAD
 ./mach build
 
 ./mach jsapi-tests
-./mach jstests -t 400 --format automation
+./mach jstests -- -t 400 --format automation --no-progress
 ./mach jit-test -- --ion -t 400 --format automation --no-progress


### PR DESCRIPTION
This PR adds coverage for `Zba` and `Zbb` codegen added in Dec 2025. These new runs are added to the slow job only.